### PR TITLE
Render statuses as they're fetched

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,18 +7,36 @@ import { useState, useEffect } from 'react';
 function App() {
   const [siteStatus, setSiteStatus] = useState('idle');
   // sets the status of the whole site to 'idle', 'success', or 'fail'
-  const [statuses, setStatuses] = useState([]);
-  // sets the statuses array, which represents statuses of endpoints
   const { hostnames, bannerConfig, urlToTitleDataMap } = config;
 
-  /** Fetches the status of an endpoint like 'user/' with a base url like
+  /** Returns the initial statuses state, with status='idle' for all endpoints,
+   * indicating that a status is still being loaded. */
+  function initStatuses() {
+    const results = [];
+    for (const [url, endpoints] of Object.entries(hostnames)) {
+      for (const endpoint of endpoints) {
+        results.push({ url: url, endpoint: endpoint, status: 'idle' });
+      }
+    }
+    return results;
+  }
+  const domainUrls = Object.keys(hostnames);
+  const initialStatuses = initStatuses();
+  const [statuses, setStatuses] = useState(initialStatuses);
+  // sets the statuses array, which represents statuses of endpoints
+
+  /**
+   * Fetches the status of an endpoint like 'user/' with a base url like
    * 'https://portal.pedscommons.org'.
    * This function returns a string status: 'success', 'fail', or 'maintenance',
    * corresponding to the different statuses in the Legend.
    *
-   * Currently, the function returns 'success' if response.status = 200, 'fail' if
-   * an error is thrown or if response.status != 200, and 'maintenance' if
-   * the json body contains a payload like {“status”: “maintenance”}.
+   * Currently, the function returns 'success' if response.status = 200,
+   * 'maintenance' if the json body contains a payload like
+   * {“status”: “maintenance”}, and 'fail' if an error is thrown, if
+   * response.status != 200, or if the fetch request
+   * times out (3 seconds).
+   *
    * @param {string} url
    * @param {string} endpoint */
   async function fetchStatus(url, endpoint) {
@@ -26,63 +44,61 @@ function App() {
     const leftTrimEndpoint = endpoint.replace(/^\//, '');
     const endpoint_url = `${rightTrimUrl}/${leftTrimEndpoint}_status`;
     try {
-      const response = await fetch(endpoint_url, { method: 'GET' });
+      const response = await fetch(endpoint_url, {
+        method: 'GET',
+        signal: AbortSignal.timeout(3000)
+      });
 
-      try {
-        const contentType = response.headers.get('content-type');
-        if (contentType && contentType.includes('application/json')) {
-          const json = await response.json();
-          if (json.status && json.status.toLowerCase() === 'maintenance') {
-            return 'maintenance';
-          }
+      const contentType = response.headers.get('content-type');
+      if (contentType && contentType.includes('application/json')) {
+        const json = await response.json();
+        if (json.status && json.status.toLowerCase() === 'maintenance') {
+          return 'maintenance';
         }
-      } catch {}
-      if (response.status === 200) {
-        return 'success';
-      } else {
-        return 'fail';
       }
+
+      return response.status === 200 ? 'success' : 'fail';
     } catch (error) {
       console.error(`Fetch failed: ${error}`);
       return 'fail';
     }
   }
+  // statuses are loaded individually as they are fetched
+  useEffect(() => {
+    const checkStatus = async () => {
+      let allStatuses = [];
 
-  /** returns an array of objects like [{ url: 'url.com', endpoint: 'endpoint', status: 'success' }, ...]*/
-  const checkStatus = async () => {
-    let result = [];
+      for (const [url, endpoints] of Object.entries(hostnames)) {
+        for (const endpoint of endpoints) {
+          const asyncStatus = (async () => {
+            const status = await fetchStatus(url, endpoint);
+            const newStatus = { url, endpoint, status };
 
-    for (const [url, endpoints] of Object.entries(hostnames)) {
-      for (const endpoint of endpoints) {
-        const status = await fetchStatus(url, endpoint);
-        result.push({
-          url: url,
-          endpoint: endpoint,
-          status: status
-        });
+            setStatuses((prev) =>
+              prev.map((s) =>
+                s.url === url && s.endpoint === endpoint ? newStatus : s
+              )
+            );
+            return newStatus;
+          })();
+
+          allStatuses.push(asyncStatus);
+        }
       }
-    }
-    return result;
-  };
 
-  useEffect(() => {
-    const fetchAllStatuses = async () => {
-      const results = await checkStatus();
-      setStatuses(results);
+      const overallSite = await Promise.all(allStatuses);
+      const allSuccessful = overallSite.every((s) => s.status === 'success');
+      const anyMaintenance = overallSite.some(
+        (s) => s.status === 'maintenance'
+      );
+
+      setSiteStatus(
+        allSuccessful ? 'success' : anyMaintenance ? 'maintenance' : 'fail'
+      );
     };
-    fetchAllStatuses();
+
+    checkStatus();
   }, []);
-
-  useEffect(() => {
-    if (statuses.length === 0) return;
-    const allSuccessful = statuses.every((s) => s.status === 'success');
-    const anyMaintenance = statuses.some((s) => s.status === 'maintenance');
-    setSiteStatus(
-      allSuccessful ? 'success' : anyMaintenance ? 'maintenance' : 'fail'
-    );
-  }, [statuses]);
-
-  const domainUrls = Object.keys(hostnames);
 
   return (
     <>

--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -5,3 +5,8 @@
   height: 100px;
   column-gap: 10px;
 }
+
+.spinner {
+  margin-left: 10px;
+  margin-top: 10px;
+}

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -1,5 +1,6 @@
 import './Banner.css';
 import Icon from '../Icon/Icon';
+import Spinner from '../Spinner/Spinner';
 
 function Banner({ siteStatus, bannerConfig }) {
   return (
@@ -8,6 +9,7 @@ function Banner({ siteStatus, bannerConfig }) {
       style={{ backgroundColor: bannerConfig.colors[siteStatus] }}>
       {siteStatus !== 'idle' && <Icon status={siteStatus} />}
       <h2> {bannerConfig.message[siteStatus]} </h2>
+      {siteStatus === 'idle' && <Spinner className='spinner' />}
     </div>
   );
 }

--- a/src/components/Spinner/Spinner.css
+++ b/src/components/Spinner/Spinner.css
@@ -1,6 +1,8 @@
 .spinner {
-  width: 100%;
-  padding: 50px 0;
+  display: flex;
+  flex-direction: column;
+  padding: 10px 0;
+  text-align: center;
 }
 
 .spinner__svg {
@@ -45,6 +47,7 @@
 
 .spinner__text {
   text-align: center;
+  font-size: 12px;
 }
 
 .spinning-spinner-cell {
@@ -53,8 +56,6 @@
 
 .spinning-spinner-cell .wrapper {
   position: relative;
-  display: flex;
-  justify-content: center;
   height: 10rem;
   margin: 10px;
 }

--- a/src/components/Spinner/Spinner.jsx
+++ b/src/components/Spinner/Spinner.jsx
@@ -1,6 +1,6 @@
 import './Spinner.css';
 
-function Spinner({ text = '', type = 'dots' }) {
+function Spinner({ text = '', type = 'dots', width = '60', height = '20' }) {
   if (type === 'spinning')
     // spinning spinner
     return (
@@ -14,12 +14,16 @@ function Spinner({ text = '', type = 'dots' }) {
   // dots
   return (
     <div className='spinner'>
-      <svg className='spinner__svg' width='60' height='20' viewBox='0 0 60 20'>
+      <svg
+        className='spinner__svg'
+        width={width}
+        height={height}
+        viewBox='0 0 60 20'>
         <circle cx='7' cy='15' r='4' />
         <circle cx='30' cy='15' r='4' />
         <circle cx='53' cy='15' r='4' />
       </svg>
-      {text && <div className='spinner__text'> {text} </div>}
+      <p> {text && <div className='spinner__text'> {text} </div>} </p>
     </div>
   );
 }

--- a/src/components/StatusGrid/StatusGrid.css
+++ b/src/components/StatusGrid/StatusGrid.css
@@ -13,7 +13,7 @@
   margin-top: -1px;
   display: flex;
   justify-content: space-between;
-  gap: 20px;
+  max-height: 120px;
 }
 
 .component-title {

--- a/src/components/StatusGrid/StatusGrid.jsx
+++ b/src/components/StatusGrid/StatusGrid.jsx
@@ -1,5 +1,6 @@
 import './StatusGrid.css';
 import Icon from '../Icon/Icon';
+import Spinner from '../Spinner/Spinner';
 
 function StatusGrid({ statuses, filterUrl, deriveTitle }) {
   return (
@@ -14,7 +15,12 @@ function StatusGrid({ statuses, filterUrl, deriveTitle }) {
               <p className='component-title'>{deriveTitle(status.endpoint)}</p>
               <p> url path: {status.endpoint} </p>
             </div>
-            <Icon status={status.status} />
+            {status.status !== 'idle' && (
+              <Icon className='icon' status={status.status} />
+            )}
+            {status.status === 'idle' && (
+              <Spinner text='loading status' width='30' />
+            )}
           </div>
         ))}
     </div>


### PR DESCRIPTION
TDLR: Render statuses as they're fetched instead of waiting for all statuses to be fetched first before rendering.

### Improvements: 

An improvement to PR #2: 
In the case where a connectivity issue occurs, the status page is able to render statuses as they're fetched, rendering a spinner for loading statuses. Then, when all statuses are loaded, the banner is rendered with the whole site status. 

####  While loading statuses.
<img width="2566" height="2282" alt="screencapture-localhost-5173-2025-07-22-11_39_49" src="https://github.com/user-attachments/assets/effbea3c-25ee-4ab5-beb3-98ade20879d5" />
  

#### Once all statuses are loaded: 
<img width="2566" height="2170" alt="screencapture-localhost-5173-2025-07-22-11_41_19" src="https://github.com/user-attachments/assets/a3cbdafb-9a3c-4292-82c4-56103e4590a9" />

